### PR TITLE
Fix game getting stuck when dying while a projectile is flying

### DIFF
--- a/bubbo-bubbo/src/game/systems/CannonSystem.ts
+++ b/bubbo-bubbo/src/game/systems/CannonSystem.ts
@@ -130,6 +130,7 @@ export class CannonSystem implements System
         // Reset rotation of cannon and reset projectile shot count
         this.cannon.rotation = 0;
         this._shotProjectiles = 0;
+        this._projectile = null;
     }
 
     /** The x-position of the cannon in game space. */


### PR DESCRIPTION
When a game over happened while a projectile was flying, the projectile variable would never get cleaned up. This resulted in the game getting into a state, where the user can not shoot anymore bubbles, not even after backing out to the main menu.