### PR TITLE
Chore: Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     with:
       game: ${{ matrix.game }}
   deploy:
-    if: github.ref_name == 'dev'
+    if: github.ref_name == 'main'
     needs: build
     environment:
       name: github-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  packages: write
+  pages: write
   id-token: write
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,16 @@ on:
     branches: [ '**' ]
   pull_request:
     branches: [ '**' ]
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 jobs:
   build:
     strategy:
@@ -12,3 +22,24 @@ jobs:
     uses: ./.github/workflows/game-workflow.yml
     with:
       game: ${{ matrix.game }}
+  deploy:
+    if: github.ref_name == 'dev'
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Below is a list of games that are currently available in this repository. Each g
 
 - Bubbo Bubbo
   - [Code](/bubbo-bubbo/README.md)
-  - [Play](https://bubbo-bubbo.netlify.app/)
+  - [Play](https://pixijs.io/open-games/bubbo-bubbo)
 
 - Puzzling Potions
   - [Code](/puzzling-potions/README.md)
-  - [Play](https://puzzling-potions.netlify.app/)
+  - [Play](https://pixijs.io/open-games/puzzling-potions)
 
 ## Tools
 

--- a/bubbo-bubbo/package.json
+++ b/bubbo-bubbo/package.json
@@ -12,7 +12,7 @@
         "start": "vite --open",
         "clean": "rimraf dist/* public/* .assetpack/*",
         "prebuild": "run-s clean format:check lint assets types",
-        "build": "vite build",
+        "build": "vite build --base \"./\"",
         "assets": "assetpack",
         "prepreview": "run-s build",
         "preview": "vite preview --open",

--- a/puzzling-potions/vite.config.js
+++ b/puzzling-potions/vite.config.js
@@ -1,4 +1,5 @@
 export default {
+    base: './',
     server: {
         host: true,
         port: 8000


### PR DESCRIPTION
### Chores

* Instead of using Netlify, we can easily deploy to GitHub Pages:
  * https://pixijs.io/open-games/bubbo-bubbo
  * https://pixijs.io/open-games/puzzling-potions
* Use relative links for Vite base (i.e., `./` instead of `/`)